### PR TITLE
Scrape non-resource action condition keys + fix resource scraping in case there is a note (e.g. CloudTrail)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,10 @@ The JSON file contains an array of service reference objects like this:
           // Additional permissions you must have in order to use the action.
           "dependentActions": []
         }
-      ]
+      ],
+
+      // Condition keys that can be specified for this action that do not depend on a resource type.
+      "conditionKeys": []
     },
     // ...
   ],


### PR DESCRIPTION
Fixes two issues:

1. CloudTrail resources are not currently scraped because of the **Note** &lt;div&gt; which appears before the resource table. The following are not scraped:

![image](https://github.com/fluggo/aws-service-auth-reference/assets/49609/e1e6427c-91ea-462b-ac4f-4fdb67d00511)

2. Action condition keys which are not for a specific resource are not synced. For instance, the JSON does not specify that the "AddTags" action can be conditioned on "aws:RequestTag/${TagKey}" and "aws:TagKeys" in the following example:

![image](https://github.com/fluggo/aws-service-auth-reference/assets/49609/40701536-83dc-424b-a4b8-4696ae3894cb)

(Both examples are from [Actions, resources, and condition keys for AWS CloudTrail](https://docs.aws.amazon.com/service-authorization/latest/reference/list_awscloudtrail.html).)